### PR TITLE
When converting BigInteger to byte array, we always retain private ke…

### DIFF
--- a/src/main/kotlin/com/radixdlt/model/ECKeyPair.kt
+++ b/src/main/kotlin/com/radixdlt/model/ECKeyPair.kt
@@ -37,7 +37,7 @@ class PrivateKey(val key: BigInteger, val curveType: EllipticCurveType) {
     }
 
     fun toHexString(): String {
-        return key.toBytesPadded(PRIVATE_KEY_SIZE).toHexString()
+        return keyByteArray().toHexString()
     }
 
     override fun hashCode(): Int {

--- a/src/test/kotlin/com/radixdlt/slip10/PrivateKeyTest.kt
+++ b/src/test/kotlin/com/radixdlt/slip10/PrivateKeyTest.kt
@@ -6,6 +6,7 @@ import com.radixdlt.model.PrivateKey
 import org.junit.jupiter.api.Test
 import kotlin.random.Random
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class PrivateKeyTest {
 
@@ -31,5 +32,23 @@ class PrivateKeyTest {
         Random.nextBytes(bytes, 1, bytes.size)
         val privateKey = PrivateKey(bytes, EllipticCurveType.Ed25519)
         assertEquals(privateKey.keyByteArray().size, PRIVATE_KEY_SIZE)
+    }
+
+    @Test
+    fun `when byte array is 32 bytes but has only 1, verify the same is returned from keyByteArray`() {
+        val byteArray =
+            byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
+        val privateKey = PrivateKey(byteArray, EllipticCurveType.Ed25519)
+        assertTrue(privateKey.keyByteArray().contentEquals(byteArray))
+    }
+
+    @Test
+    fun `when byte array is only one byte (1), verify that output is also one but has 32 bytes length`() {
+        val byteArray =
+            byteArrayOf(1)
+        val outputByteArray =
+            byteArrayOf(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)
+        val privateKey = PrivateKey(byteArray, EllipticCurveType.Ed25519)
+        assertTrue(privateKey.keyByteArray().contentEquals(outputByteArray))
     }
 }


### PR DESCRIPTION
…y size length, and fullfill leading zeros if needed.

I discovered this issue by mistake for specific derivation path that causes PrivateKey to initialised from byte array that has leading zero. 
Since we use BigDecimal, it turns out that by design it strips all leading zeros causing private key to be less than 32 bytes.

I added method that we should be accessing private key byte array that ensures we always gonna have accurate key length with retained value.