### PR TITLE
[DO-1619] Snyk integration in Github workflows

### DIFF
--- a/.github/workflows/pr_and_main.yml
+++ b/.github/workflows/pr_and_main.yml
@@ -3,8 +3,8 @@ name: "Snyk scan"
 on:
   pull_request:
   push:
-#    branches:
-#      - main
+    branches:
+      - main
 
 jobs:
 
@@ -29,17 +29,5 @@ jobs:
         with:
           args: --all-projects --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high
           command: code test
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
-  snyk_online_monitor:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
-      - name: Enable Snyk online monitoring to check for vulnerabilities
-        uses: snyk/actions/gradle-jdk17@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
-        with:
-          args: --all-projects --org=${{ secrets.SNYK_ORG_ID }}
-          command: monitor
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,3 +22,34 @@ jobs:
           arguments: publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  snyk_online_monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      - name: Enable Snyk online monitoring to check for vulnerabilities
+        uses: snyk/actions/gradle-jdk17@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
+        with:
+          args: --all-projects --org=${{ secrets.SNYK_ORG_ID }}
+          command: monitor
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+  publish_sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      - name: Generate SBOM
+        uses: snyk/actions/gradle-jdk17@b98d498629f1c368650224d6d212bf7dfa89e4bf # v0.4.0
+        with:
+          args: --all-projects --org=${{ secrets.SNYK_ORG_ID }} --format=cyclonedx1.4+json --json-file-output sbom.json
+          command: sbom
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      - name: Upload SBOM
+        uses: svenstaro/upload-release-action@2b9d2847a97b04d02ad5c3df2d3a27baa97ce689 # v2.6.1
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: sbom.json
+          tag: ${{ github.ref }}
+          overwrite: true


### PR DESCRIPTION
## Description
[Core Apps team Snyk integration](https://radixdlt.atlassian.net/browse/DO-1619)

Added 4 Github jobs:
- `snyk_scan_deps_licences` - Runs before build. Detects vulnerabilities in dependencies with high severity and licenses defined as high severity. No push to Snyk Dashboard - results visible only in Github workflow.

- `snyk_scan_code` - Runs before build. Detects vulnerabilities in source code with high severity. No push to Snyk Dashboard - results visible only in Github workflow.

- `snyk_online_monitor` - Runs after publish. Enables online monitoring of the dependencies used in the published build to check for vulnerabilities. Findings are visible in [Snyk Dashboard](https://app.snyk.io/org/core-apps-2bi/projects?groupBy=targets&searchQuery=&sortBy=highest+severity&filters[Show]=vuln-groups&filters[Integrations]=&before&after)

- `publish_sbom` - Runs on published release. Generates `sbom.json` and adds it into current release.

